### PR TITLE
🛡️ Sentinel: [security improvement] Add security headers to Firebase config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,6 @@
+# Sentinel Journal
+
+## 2024-05-22 - Missing Security Headers in Firebase Configuration
+**Vulnerability:** The `firebase.json` configuration lacked standard security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy), exposing the application to clickjacking, MIME sniffing, and other common web vulnerabilities.
+**Learning:** Static sites hosted on Firebase do not include these headers by default. While CSP is also important, it requires careful configuration to avoid breaking functionality (e.g. styles, scripts, external APIs), so start with the safer headers first.
+**Prevention:** Always verify `firebase.json` includes a `headers` section with `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, and `Strict-Transport-Security`.

--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,33 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "SAMEORIGIN"
+          },
+          {
+            "key": "X-XSS-Protection",
+            "value": "1; mode=block"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

🚨 Severity: MEDIUM
💡 Vulnerability: Missing standard security headers in Firebase Hosting configuration.
🎯 Impact: Lack of headers like HSTS, X-Frame-Options, and X-Content-Type-Options exposes the site to clickjacking, protocol downgrade attacks, and MIME type confusion.
🔧 Fix: Added the following headers to `firebase.json`:
  - `Strict-Transport-Security`
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: SAMEORIGIN`
  - `X-XSS-Protection: 1; mode=block`
  - `Referrer-Policy: strict-origin-when-cross-origin`

Also initialized `.jules/sentinel.md` with a journal entry regarding this finding.

✅ Verification:
- Verified `firebase.json` syntax.
- Verified site build (`pnpm docs:build`) succeeds.

---
*PR created automatically by Jules for task [14808242583597439990](https://jules.google.com/task/14808242583597439990) started by @kou256*