### PR TITLE
🛡️ Sentinel: Add security headers to firebase.json

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-06 - Missing Security Headers in Firebase Hosting
+**Vulnerability:** The `firebase.json` configuration lacked standard security headers like HSTS, X-Content-Type-Options, X-Frame-Options, and Referrer-Policy.
+**Learning:** Default Firebase Hosting configurations do not automatically include these headers; they must be explicitly defined.
+**Prevention:** Always audit `firebase.json` for the `headers` section and ensure a "secure by default" policy is applied to all routes.

--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,29 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "SAMEORIGIN"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Added standard security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy) to `firebase.json` to enhance security. Created `.jules/sentinel.md` to track this security improvement. Verified that the build still succeeds.

---
*PR created automatically by Jules for task [8802375401839619493](https://jules.google.com/task/8802375401839619493) started by @kou256*