### PR TITLE
🛡️ Sentinel: [HIGH] Add security headers to Firebase config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,7 @@
+# 🛡️ Sentinel's Journal
+
+## 2025-02-12 - Missing Security Headers in Firebase Hosting
+
+**Vulnerability:** The application was deployed to Firebase Hosting without any explicit HTTP security headers (HSTS, X-Frame-Options, etc.), leaving users vulnerable to man-in-the-middle attacks, clickjacking, and MIME-sniffing.
+**Learning:** Static site generators like VitePress often require explicit server configuration for security headers as they don't have a backend to set them dynamically. Implementing a strict Content Security Policy (CSP) is challenging due to VitePress's reliance on inline scripts and styles for hydration, necessitating 'unsafe-inline' unless complex build-time hashing is implemented.
+**Prevention:** Always include a `headers` configuration block in `firebase.json` for static sites to enforce security policies at the CDN edge.

--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,29 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains"
+          },
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
🛡️ **Sentinel Security Update**

**Severity:** HIGH

**Vulnerability:**
The application was deployed to Firebase Hosting without explicit HTTP security headers. This configuration leaves users vulnerable to:
- **Man-in-the-Middle (MITM) attacks**: Due to lack of HSTS enforcement.
- **MIME-sniffing attacks**: Browsers might interpret files as a different MIME type than declared.
- **Clickjacking**: The site could be embedded in an iframe on a malicious site.

**Fix:**
Implemented a `headers` configuration block in `firebase.json` to enforce the following policies on all routes (`**`):
- `Strict-Transport-Security`: `max-age=31536000; includeSubDomains` (Force HTTPS for 1 year)
- `X-Content-Type-Options`: `nosniff` (Prevent MIME sniffing)
- `X-Frame-Options`: `DENY` (Prevent clickjacking completely)
- `Referrer-Policy`: `strict-origin-when-cross-origin` (Protect referrer data while maintaining functionality)

**Verification:**
- Validated `firebase.json` syntax.
- Verified that `pnpm docs:build` completes successfully with the new configuration.
- **Note:** Header effectiveness must be verified on the deployed environment as local `vite preview` does not emulate Firebase headers.

**Journal:**
- Created `.jules/sentinel.md` and recorded the finding and the constraints regarding Content Security Policy (CSP) with VitePress.

---
*PR created automatically by Jules for task [6878468552436892974](https://jules.google.com/task/6878468552436892974) started by @kou256*