### PR TITLE
🛡️ Sentinel: Add Subresource Integrity (SRI) to external stylesheet

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,12 @@ export default defineConfig({
   title: "zuikou.dev",
   description: "kou256のポートフォリオサイト",
   head: [
-    ['link', { rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/gh/devicons/devicon@2.17.0/devicon.min.css', integrity: 'sha384-6iv3tXABd3c9DYulXujJl8n22ahn/12f45MomxoPv6jBX4LBE4gNJjfkx5mAKIqR', crossorigin: 'anonymous' }]
+    ['link', {
+      rel: 'stylesheet',
+      href: 'https://cdn.jsdelivr.net/gh/devicons/devicon@2.17.0/devicon.min.css',
+      integrity: 'sha384-6iv3tXABd3c9DYulXujJl8n22ahn/12f45MomxoPv6jBX4LBE4gNJjfkx5mAKIqR',
+      crossorigin: 'anonymous'
+    }]
   ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,7 @@ export default defineConfig({
   title: "zuikou.dev",
   description: "kou256のポートフォリオサイト",
   head: [
-    ['link', { rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/gh/devicons/devicon@2.17.0/devicon.min.css' }]
+    ['link', { rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/gh/devicons/devicon@2.17.0/devicon.min.css', integrity: 'sha384-6iv3tXABd3c9DYulXujJl8n22ahn/12f45MomxoPv6jBX4LBE4gNJjfkx5mAKIqR', crossorigin: 'anonymous' }]
   ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config


### PR DESCRIPTION
🛡️ Sentinel: Add Subresource Integrity (SRI) to external stylesheet

### 💡 Context
The project loads an external stylesheet (`devicon.min.css`) from a CDN (`cdn.jsdelivr.net`). By default, there is no verification that the loaded file hasn't been tampered with.

### 🎯 Impact
If the CDN is compromised, an attacker could potentially inject malicious CSS or scripts into the site.

### 🔧 Fix
Added `integrity` and `crossorigin="anonymous"` attributes to the `link` tag in `docs/.vitepress/config.mts`. This ensures the browser verifies the file's hash against the expected value before executing it.

### ✅ Verification
1. Run `pnpm install`
2. Run `pnpm docs:build`
3. Verify that the site builds successfully and the stylesheet is loaded properly.

---
*PR created automatically by Jules for task [7312103366523100643](https://jules.google.com/task/7312103366523100643) started by @kou256*