### PR TITLE
🛡️ Sentinel: [MEDIUM] Add Subresource Integrity (SRI) for external CSS

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,7 +5,13 @@ export default defineConfig({
   title: "zuikou.dev",
   description: "kou256のポートフォリオサイト",
   head: [
-    ['link', { rel: 'stylesheet', href: 'https://cdn.jsdelivr.net/gh/devicons/devicon@2.17.0/devicon.min.css' }]
+    // 🛡️ Sentinel: Added Subresource Integrity (SRI) to prevent malicious code execution if CDN is compromised
+    ['link', {
+      rel: 'stylesheet',
+      href: 'https://cdn.jsdelivr.net/gh/devicons/devicon@2.17.0/devicon.min.css',
+      integrity: 'sha384-6iv3tXABd3c9DYulXujJl8n22ahn/12f45MomxoPv6jBX4LBE4gNJjfkx5mAKIqR',
+      crossorigin: 'anonymous'
+    }]
   ],
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Loading an external stylesheet from a CDN without Subresource Integrity (SRI) validation.
🎯 Impact: If the CDN is compromised, an attacker could replace the CSS file with malicious content, leading to CSS-based attacks, data exfiltration, or site defacement.
🔧 Fix: Added `integrity` and `crossorigin` attributes to the `<link>` tag in `docs/.vitepress/config.mts` for `devicon.min.css`.
✅ Verification: Ran `pnpm docs:build` and visually verified the generated HTML contains the correct attributes and that the browser does not block the legitimate file.

---
*PR created automatically by Jules for task [5398841895107489655](https://jules.google.com/task/5398841895107489655) started by @kou256*