### PR TITLE
🛡️ Sentinel: [security improvement] Add Firebase Security Headers

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-04-10 - VitePress Content Security Policy Constraints
+**Vulnerability:** Weak Content Security Policy (CSP) or difficulty implementing a strict CSP.
+**Learning:** VitePress architecture fundamentally relies on inline scripts and styles for its core functionality and component rendering. Generating a strict CSP that blocks `'unsafe-inline'` will break the site.
+**Prevention:** When adding a CSP to a VitePress project (e.g., via Firebase Hosting headers), explicitly include `'unsafe-inline'` for both `script-src` and `style-src` directives to ensure the site remains functional, while still restricting other directives like `object-src` and `base-uri`.

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,37 @@
+{
+  "hosting": {
+    "public": "docs/.vitepress/dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "headers": [
+      {
+        "source": "**/*",
+        "headers": [
+          {
+            "key": "X-Content-Type-Options",
+            "value": "nosniff"
+          },
+          {
+            "key": "X-Frame-Options",
+            "value": "DENY"
+          },
+          {
+            "key": "X-XSS-Protection",
+            "value": "1; mode=block"
+          },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains"
+          },
+          {
+            "key": "Content-Security-Policy",
+            "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; font-src 'self' https://cdn.jsdelivr.net; img-src 'self' data: https:; object-src 'none'; base-uri 'self';"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing HTTP security headers in the static hosting configuration.
🎯 Impact: Without these headers, the site is theoretically more susceptible to various injection attacks, clickjacking, and MIME-sniffing, although the static nature of VitePress mitigates many risks.
🔧 Fix: Added a `firebase.json` file configuring Firebase Hosting to serve `docs/.vitepress/dist` and apply a comprehensive set of security headers, including a Content-Security-Policy (CSP) tailored for VitePress. A `.jules/sentinel.md` journal entry was also created to document the CSP constraints discovered during implementation.
✅ Verification: The build was run successfully with `pnpm docs:build`. Deployment to Firebase Hosting will automatically apply the headers defined in `firebase.json`.

---
*PR created automatically by Jules for task [8814642519813387569](https://jules.google.com/task/8814642519813387569) started by @kou256*